### PR TITLE
Bug fix for enkf analysis steps when using t(tv) as a control vector variable for regional FV3 DA

### DIFF
--- a/src/enkf/gridio_fv3reg.f90
+++ b/src/enkf/gridio_fv3reg.f90
@@ -400,7 +400,7 @@ contains
     real(r_single), dimension(:,:), allocatable ::pswork
     real(r_single), dimension(:,:,:), allocatable ::workvar3d,workinc3d,workinc3d2,uworkvar3d,&
                         vworkvar3d,tvworkvar3d,tsenworkvar3d,&
-                        workprsi,qworkvar3d,qsvworkvar3d,qbgworkvar3d
+                        workprsi,qworkvar3d,qbgworkvar3d
 
     !----------------------------------------------------------------------
     ! Define variables required by for extracting netcdf variable
@@ -447,7 +447,6 @@ contains
     allocate(workinc3d(nx_res,ny_res,nlevs),workinc3d2(nx_res,ny_res,nlevsp1))
     allocate(workvar3d(nx_res,ny_res,nlevs))
     allocate(qworkvar3d(nx_res,ny_res,nlevs))
-    allocate(qsvworkvar3d(nx_res,ny_res,nlevs))
     allocate(qbgworkvar3d(nx_res,ny_res,nlevs))
     allocate(tvworkvar3d(nx_res,ny_res,nlevs))
 
@@ -548,8 +547,6 @@ contains
        enddo
        enddo
        qworkvar3d=qbgworkvar3d+workinc3d
-       ! save the original qworkvar3d before writing
-       qsvworkvar3d=qworkvar3d
 
        call write_fv3_restart_data3d(varstrname,fv3filename,file_id,qworkvar3d)
        do k=1,nlevs
@@ -557,10 +554,10 @@ contains
              write(6,*) 'WRITEregional : sphum ',                           &
                  & k, minval(qworkvar3d(:,:,k)), maxval(qworkvar3d(:,:,k))
        enddo
-       ! during write_fv3_restart_data3d, qworkvar3d got all its dimensions in
-       ! revered order. So, restore the original qworkvar3d after writing, so
+       ! During write_fv3_restart_data3d, qworkvar3d got all its dimensions in
+       ! revered order. So, re-calculate qworkvar3d after being written, so
        ! that it can be used below for the tsen calculation if needed.
-       qworkvar3d=qsvworkvar3d
+       qworkvar3d=qbgworkvar3d+workinc3d
     end if
 
     if (tv_ind>0 .or. tsen_ind>0 ) then
@@ -680,7 +677,6 @@ contains
     if(allocated(pswork))       deallocate(pswork)
     if(allocated(tvworkvar3d))  deallocate(tvworkvar3d)
     if(allocated(qworkvar3d))   deallocate(qworkvar3d)
-    if(allocated(qsvworkvar3d)) deallocate(qsvworkvar3d)
     if(allocated(qbgworkvar3d)) deallocate(qbgworkvar3d)
 
     end do backgroundloop ! loop over backgrounds to read in

--- a/src/enkf/gridio_fv3reg.f90
+++ b/src/enkf/gridio_fv3reg.f90
@@ -548,16 +548,17 @@ contains
        enddo
        qworkvar3d=qbgworkvar3d+workinc3d
 
-       call write_fv3_restart_data3d(varstrname,fv3filename,file_id,qworkvar3d)
+       ! In write_fv3_restart_data3d, the input workvar3d will get all its
+       ! dimensions in revered order. So, use workvar3d for writing and leave
+       ! qworkvar3d unchanged so that it can be used below for the tsen
+       ! calculation if needed.
+       workvar3d=qworkvar3d
+       call write_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
        do k=1,nlevs
           if (nproc .eq. 0)                                                 &
              write(6,*) 'WRITEregional : sphum ',                           &
-                 & k, minval(qworkvar3d(:,:,k)), maxval(qworkvar3d(:,:,k))
+                 & k, minval(workvar3d(:,:,k)), maxval(workvar3d(:,:,k))
        enddo
-       ! During write_fv3_restart_data3d, qworkvar3d got all its dimensions in
-       ! revered order. So, re-calculate qworkvar3d after being written, so
-       ! that it can be used below for the tsen calculation if needed.
-       qworkvar3d=qbgworkvar3d+workinc3d
     end if
 
     if (tv_ind>0 .or. tsen_ind>0 ) then

--- a/src/enkf/gridio_fv3reg.f90
+++ b/src/enkf/gridio_fv3reg.f90
@@ -3,17 +3,17 @@ module gridio
   !========================================================================
 
   !$$$ Module documentation block
-  ! 
+  !
   ! This module contains various routines to ingest and update
   ! variables from FV3-LAM warmstart files
   !
   ! prgmmr: Winterbottom        org: ESRL/PSD1       date: 2011-11-30
   !
   ! program history log:
-  !   
+  !
   !   2011-11-30 Winterbottom - Initial version.
   !
-  !   2019-01- Ting  --  modified for fv3-lam  
+  !   2019-01- Ting  --  modified for fv3-lam
   ! attributes:
   !   language:  f95
   !
@@ -46,26 +46,24 @@ module gridio
 
 contains
   subroutine readgriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,ntimes,fileprefixes,filesfcprefixes,reducedgrid,vargrid,qsat)
-   use constants, only:zero,one,half,fv, max_varname_length
-   use gridinfo,only: eta1_ll
-   use netcdf, only: nf90_open,nf90_close,nf90_get_var,nf90_noerr
-   use netcdf, only: nf90_inq_dimid,nf90_inq_varid
-   use netcdf, only: nf90_nowrite,nf90_write,nf90_inquire,nf90_inquire_dimension
-   implicit none
-   integer, intent(in) :: nanal1,nanal2, n2d, n3d, ndim, ntimes
-   character(len=max_varname_length), dimension(n2d), intent(in) :: vars2d
-   character(len=max_varname_length), dimension(n3d), intent(in) :: vars3d
-   integer, dimension(0:n3d), intent(in)        :: levels
-   character(len=120), dimension(7), intent(in) :: fileprefixes
-   character(len=120), dimension(7), intent(in)  :: filesfcprefixes
-   logical, intent(in) :: reducedgrid
+    use constants, only:zero,one,half,fv, max_varname_length
+    use gridinfo,only: eta1_ll
+    use netcdf, only: nf90_open,nf90_close,nf90_get_var,nf90_noerr
+    use netcdf, only: nf90_inq_dimid,nf90_inq_varid
+    use netcdf, only: nf90_nowrite,nf90_write,nf90_inquire,nf90_inquire_dimension
+    implicit none
+    integer, intent(in) :: nanal1,nanal2, n2d, n3d, ndim, ntimes
+    character(len=max_varname_length), dimension(n2d), intent(in) :: vars2d
+    character(len=max_varname_length), dimension(n3d), intent(in) :: vars3d
+    integer, dimension(0:n3d), intent(in)        :: levels
+    character(len=120), dimension(7), intent(in) :: fileprefixes
+    character(len=120), dimension(7), intent(in)  :: filesfcprefixes
+    logical, intent(in) :: reducedgrid
 
-   real(r_single), dimension(npts,ndim,ntimes,nanal2-nanal1+1),  intent(out) :: vargrid
-   real(r_double), dimension(npts,nlevs,ntimes,nanal2-nanal1+1), intent(out) :: qsat
+    real(r_single), dimension(npts,ndim,ntimes,nanal2-nanal1+1),  intent(out) :: vargrid
+    real(r_double), dimension(npts,nlevs,ntimes,nanal2-nanal1+1), intent(out) :: qsat
 
-
-
-    ! Define local variables 
+    ! Define local variables
     character(len=500) :: filename
     character(len=:),allocatable :: fv3filename
     character(len=7)   :: charnanal
@@ -78,8 +76,7 @@ contains
 
     ! Define variables required for netcdf variable I/O
     character(len=12) :: varstrname
-     
-   
+
     character(len=1) char_tile
     character(len=24),parameter :: myname_ = 'fv3: getgriddata'
 
@@ -102,7 +99,7 @@ contains
     delp_ind   = getindex(vars3d, 'delp')   ! delp (3D)
     oz_ind  = getindex(vars3d, 'oz')  ! Oz (3D)
     tsen_ind = getindex(vars3d, 'tsen') !sensible T (3D)
-!    prse_ind = getindex(vars3d, 'prse') ! pressure
+    !prse_ind = getindex(vars3d, 'prse') ! pressure
 
     ps_ind  = getindex(vars2d, 'ps')  ! Ps (2D)
     sst_ind = getindex(vars2d, 'sst') ! SST (2D)
@@ -125,270 +122,252 @@ contains
 
     ! Define character string for ensemble member file
     if (nanal > 0) then
-      write(charnanal,'(a3, i3.3)') 'mem', nanal
+        write(charnanal,'(a3, i3.3)') 'mem', nanal
     else
-      charnanal = 'ensmean'
+       charnanal = 'ensmean'
     endif
 
-     do ntile=1,ntiles
-      nn_tile0=(ntile-1)*nx_res*ny_res
-      write(char_tile, '(i1)') ntile
+    do ntile=1,ntiles
 
-      filename = "fv3sar_tile"//char_tile//"_"//trim(charnanal)
-      fv3filename=trim(adjustl(filename))//"_dynvartracer"
+    nn_tile0=(ntile-1)*nx_res*ny_res
+    write(char_tile, '(i1)') ntile
+
+    filename = "fv3sar_tile"//char_tile//"_"//trim(charnanal)
+    fv3filename=trim(adjustl(filename))//"_dynvartracer"
 
     !----------------------------------------------------------------------
     ! read u-component
-      call nc_check( nf90_open(trim(adjustl(fv3filename)),nf90_nowrite,file_id),&
-                    myname_,'open: '//trim(adjustl(fv3filename)) )
+    call nc_check( nf90_open(trim(adjustl(fv3filename)),nf90_nowrite,file_id),&
+                   myname_,'open: '//trim(adjustl(fv3filename)) )
 
     !----------------------------------------------------------------------
     ! Update u and v variables (same for NMM and ARW)
-  
+
     if (u_ind > 0) then
-    allocate(uworkvar3d(nx_res,ny_res+1,nlevs))
-      varstrname = 'u'
+       allocate(uworkvar3d(nx_res,ny_res+1,nlevs))
+       varstrname = 'u'
 
-      call read_fv3_restart_data3d(varstrname,fv3filename,file_id,uworkvar3d)
-      do k=1,nlevs
+       call read_fv3_restart_data3d(varstrname,fv3filename,file_id,uworkvar3d)
+       do k=1,nlevs
           nn = nn_tile0
-        do j=1,ny_res
-         do i=1,nx_res
-            nn=nn+1
-            vargrid(nn,levels(u_ind-1)+k,nb,ne)=uworkvar3d(i,j,k) 
-         enddo
-        enddo
-      enddo
-      do k = levels(u_ind-1)+1, levels(u_ind)
-          if (nproc .eq. 0)                                               &
+       do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             vargrid(nn,levels(u_ind-1)+k,nb,ne)=uworkvar3d(i,j,k)
+          enddo
+       enddo
+       enddo
+       do k = levels(u_ind-1)+1, levels(u_ind)
+          if (nproc .eq. 0)                                              &
              write(6,*) 'READFVregional : u ',                           &
-                 & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
-      enddo
-
-    deallocate(uworkvar3d)
+                  & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
+       enddo
+       deallocate(uworkvar3d)
     endif
+
     if (v_ind > 0) then
-    allocate(vworkvar3d(nx_res+1,ny_res,nlevs))
+       allocate(vworkvar3d(nx_res+1,ny_res,nlevs))
        varstrname = 'v'
        call read_fv3_restart_data3d(varstrname,fv3filename,file_id,vworkvar3d)
-    do k=1,nlevs
-       nn = nn_tile0
+       do k=1,nlevs
+          nn = nn_tile0
        do j=1,ny_res
-         do i=1,nx_res
-            nn=nn+1
-            vargrid(nn,levels(v_ind-1)+k,nb,ne)=vworkvar3d(i,j,k) 
-         enddo
+          do i=1,nx_res
+             nn=nn+1
+             vargrid(nn,levels(v_ind-1)+k,nb,ne)=vworkvar3d(i,j,k)
+          enddo
        enddo
-    enddo
-    do k = levels(v_ind-1)+1, levels(v_ind)
-        if (nproc .eq. 0)                                               &
+       enddo
+       do k = levels(v_ind-1)+1, levels(v_ind)
+          if (nproc .eq. 0)                                              &
              write(6,*) 'READFVregional : v ',                           &
-                 & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
-    enddo
-    deallocate(vworkvar3d)
-
+                  & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
+       enddo
+       deallocate(vworkvar3d)
     endif
+
     if (delp_ind > 0) then
-        varstrname = 'delp'
-        call read_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
-           do k=1,nlevs
-              nn = nn_tile0
-              do j=1,ny_res
-                 do i=1,nx_res
-                    nn=nn+1
-                    vargrid(nn,levels(delp_ind-1)+k,nb,ne)=workvar3d(i,j,k) 
-                  enddo
-               enddo
-            enddo
-            do k = levels(delp_ind-1)+1, levels(delp_ind)
-                 if (nproc .eq. 0)                                               &
-                    write(6,*) 'READFVregional : delp ',                           &
-                         & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
-             enddo
-
+       varstrname = 'delp'
+       call read_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
+       do k=1,nlevs
+          nn = nn_tile0
+       do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             vargrid(nn,levels(delp_ind-1)+k,nb,ne)=workvar3d(i,j,k)
+          enddo
+       enddo
+       enddo
+       do k = levels(delp_ind-1)+1, levels(delp_ind)
+          if (nproc .eq. 0)                                                 &
+             write(6,*) 'READFVregional : delp ',                           &
+                  & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
+       enddo
     endif
+
     if (q_ind > 0) then
-        varstrname = 'sphum'
-        call read_fv3_restart_data3d(varstrname,fv3filename,file_id,qworkvar3d)
-           do k=1,nlevs
-              nn = nn_tile0
-              do j=1,ny_res
-                 do i=1,nx_res
-                    nn=nn+1
-                    vargrid(nn,levels(q_ind-1)+k,nb,ne)=qworkvar3d(i,j,k) 
-                  enddo
-               enddo
-            enddo
-            do k = levels(q_ind-1)+1, levels(q_ind)
-                 if (nproc .eq. 0)                                               &
-                    write(6,*) 'READFVregional : q ',                           &
-                         & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
-             enddo
-
+       varstrname = 'sphum'
+       call read_fv3_restart_data3d(varstrname,fv3filename,file_id,qworkvar3d)
+       do k=1,nlevs
+          nn = nn_tile0
+       do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             vargrid(nn,levels(q_ind-1)+k,nb,ne)=qworkvar3d(i,j,k)
+          enddo
+       enddo
+       enddo
+       do k = levels(q_ind-1)+1, levels(q_ind)
+          if (nproc .eq. 0)                                               &
+             write(6,*) 'READFVregional : q ',                            &
+                  & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
+       enddo
     endif
-    if (tv_ind > 0.or.tsen_ind) then
+
+    if (tv_ind > 0 .or. tsen_ind > 0) then
        allocate(tsenworkvar3d(nx_res,ny_res,nlevs))
        varstrname = 'T'
        call read_fv3_restart_data3d(varstrname,fv3filename,file_id,tsenworkvar3d)
-      if(tv_ind > 0) then
-          if(.not.  (q_ind > 0)) then
+       if (tv_ind > 0) then
+          if (.not.  (q_ind > 0)) then
              varstrname = 'sphum'
-           call read_fv3_restart_data3d(varstrname,fv3filename,file_id,qworkvar3d)
+             call read_fv3_restart_data3d(varstrname,fv3filename,file_id,qworkvar3d)
           endif
-           do k=1,nlevs
-            do j=1,ny_res
-              do i=1,nx_res
-               workvar3d(i,j,k)=tsenworkvar3d(i,j,k)*(one+fv*qworkvar3d(i,j,k))
-              enddo
-             enddo
-            enddo
-           tvworkvar3d=workvar3d
-        else! tsen_id >0
-           workvar3d=tsenworkvar3d
-           tvworkvar3d=workvar3d*(one+fv*qworkvar3d)
-        endif
-           tmp_ind=max(tv_ind,tsen_ind) !then can't be both >0 
-           do k=1,nlevs
-               nn = nn_tile0
-             do j=1,ny_res
-              do i=1,nx_res
-                 nn=nn+1
-                 vargrid(nn,levels(tmp_ind-1)+k,nb,ne)=workvar3d(i,j,k) 
-              enddo
-             enddo
-           enddo
-           do k = levels(tmp_ind-1)+1, levels(tmp_ind)
-              if (nproc .eq. 0)   then                                           
-                 write(6,*) 'READFVregional : tv or tsen ',                           &
-                     & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
-              endif
-           enddo
+          do k=1,nlevs
+          do j=1,ny_res
+          do i=1,nx_res
+             workvar3d(i,j,k)=tsenworkvar3d(i,j,k)*(one+fv*qworkvar3d(i,j,k))
+          enddo
+          enddo
+          enddo
+          tvworkvar3d=workvar3d
+       else! tsen_id >0
+          workvar3d=tsenworkvar3d
+          tvworkvar3d=workvar3d*(one+fv*qworkvar3d)
+       endif
+       tmp_ind=max(tv_ind,tsen_ind) !then can't be both >0
+       do k=1,nlevs
+           nn = nn_tile0
+         do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             vargrid(nn,levels(tmp_ind-1)+k,nb,ne)=workvar3d(i,j,k)
+          enddo
+         enddo
+       enddo
+       do k = levels(tmp_ind-1)+1, levels(tmp_ind)
+          if (nproc .eq. 0) then
+             write(6,*) 'READFVregional : tv or tsen ',                           &
+                 & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
+          endif
+       enddo
+    endif
+    if(allocated(tsenworkvar3d)) deallocate(tsenworkvar3d)
 
-        endif
-   if(allocated(tsenworkvar3d)) deallocate(tsenworkvar3d)
-           
-
-    
-   if (oz_ind > 0) then
+    if (oz_ind > 0) then
        varstrname = 'o3mr'
        call read_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
-      do k=1,nlevs
+       do k=1,nlevs
           nn = nn_tile0
-        do j=1,ny_res
-         do i=1,nx_res
-            nn=nn+1
-            vargrid(nn,levels(oz_ind-1)+k,nb,ne)=workvar3d(i,j,k) 
-         enddo
-        enddo
-      enddo
-      do k = levels(oz_ind-1)+1, levels(oz_ind)
+       do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             vargrid(nn,levels(oz_ind-1)+k,nb,ne)=workvar3d(i,j,k)
+          enddo
+       enddo
+       enddo
+       do k = levels(oz_ind-1)+1, levels(oz_ind)
           if (nproc .eq. 0)                                               &
              write(6,*) 'READFVregional : oz ',                           &
-                 & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
+                  & k, minval(vargrid(:,k,nb,ne)), maxval(vargrid(:,k,nb,ne))
        enddo
-
     endif
-   
+
     call nc_check( nf90_close(file_id),&
          myname_,'close '//trim(fv3filename) )
+
     ! set SST to zero for now
     if (sst_ind > 0) then
        vargrid(:,levels(n3d)+sst_ind,nb,ne) = zero
     endif
 
-
     !----------------------------------------------------------------------
     ! Allocate memory for variables computed within routine
- 
+
     if (ps_ind > 0) then
-      allocate(workprsi(nx_res,ny_res,nlevsp1))
-      allocate(pswork(nx_res,ny_res))
-      fv3filename=trim(adjustl(filename))//"_dynvartracer"
-      call nc_check( nf90_open(trim(adjustl(fv3filename)),nf90_nowrite,file_id),&
-                      myname_,'open: '//trim(adjustl(fv3filename)) )
-      call read_fv3_restart_data3d('delp',fv3filename,file_id,workvar3d)  
+       allocate(workprsi(nx_res,ny_res,nlevsp1))
+       allocate(pswork(nx_res,ny_res))
+       fv3filename=trim(adjustl(filename))//"_dynvartracer"
+       call nc_check( nf90_open(trim(adjustl(fv3filename)),nf90_nowrite,file_id),&
+                       myname_,'open: '//trim(adjustl(fv3filename)) )
+       call read_fv3_restart_data3d('delp',fv3filename,file_id,workvar3d)
        !print *,'min/max delp',ntile,minval(delp),maxval(delp)
-      call nc_check( nf90_close(file_id),&
-      myname_,'close '//trim(fv3filename) )
-      workprsi(:,:,nlevsp1)=eta1_ll(nlevsp1) !etal_ll is needed
-      do i=nlevs,1,-1
-        workprsi(:,:,i)=workvar3d(:,:,i)*0.01_r_kind+workprsi(:,:,i+1)
-      enddo
- 
-      pswork(:,:)=workprsi(:,:,1)
+       call nc_check( nf90_close(file_id),&
+       myname_,'close '//trim(fv3filename) )
+       workprsi(:,:,nlevsp1)=eta1_ll(nlevsp1) !etal_ll is needed
+       do i=nlevs,1,-1
+          workprsi(:,:,i)=workvar3d(:,:,i)*0.01_r_kind+workprsi(:,:,i+1)
+       enddo
+       pswork(:,:)=workprsi(:,:,1)
 
+       nn = nn_tile0
+       do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             vargrid(nn,levels(n3d)+ps_ind, nb,ne) =pswork(i,j)
+          enddo
+       enddo
 
-
-      nn = nn_tile0
-      do j=1,ny_res
-         do i=1,nx_res
-            nn=nn+1
-            vargrid(nn,levels(n3d)+ps_ind, nb,ne) =pswork(i,j) 
-         enddo
-      enddo
-
-      
-      
-
-      
-      do k=1,nlevs
-        do j=1,ny_res  
-         do i=1,nx_res
-           workvar3d(i,j,k)=(workprsi(i,j,k)+workprsi(i,j,k+1))*half
-         enddo
-        enddo
-      enddo
-      ice=.true.  !tothink
-      if (pseudo_rh) then
-        call genqsat1(qworkvar3d,qsatworkvar3d,workvar3d,tvworkvar3d,ice,  &
-                     nx_res*ny_res,nlevs)
-      else
-        qsatworkvar3d(:,:,:) = 1._r_double
-      endif
-      do k=1,nlevs
+       do k=1,nlevs
+       do j=1,ny_res
+       do i=1,nx_res
+          workvar3d(i,j,k)=(workprsi(i,j,k)+workprsi(i,j,k+1))*half
+       enddo
+       enddo
+       enddo
+       ice=.true.  !tothink
+       if (pseudo_rh) then
+          call genqsat1(qworkvar3d,qsatworkvar3d,workvar3d,tvworkvar3d,ice,  &
+                        nx_res*ny_res,nlevs)
+       else
+          qsatworkvar3d(:,:,:) = 1._r_double
+       endif
+       do k=1,nlevs
           nn = nn_tile0
-      do j=1,ny_res
-         do i=1,nx_res
-            nn=nn+1
-            qsat(nn,k,nb,ne)=qsatworkvar3d(i,j,k) 
-         enddo
-      enddo
-      enddo
-            
-          
+       do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             qsat(nn,k,nb,ne)=qsatworkvar3d(i,j,k)
+          enddo
+       enddo
+       enddo
 
-
-
-      if(allocated(workprsi))     deallocate(workprsi)
-      if(allocated(pswork))     deallocate(pswork)
-      if(allocated(tvworkvar3d)) deallocate(tvworkvar3d)
-      if(allocated(qworkvar3d)) deallocate(qworkvar3d)
-      if(allocated(qsatworkvar3d)) deallocate(qsatworkvar3d)
+       if(allocated(workprsi))     deallocate(workprsi)
+       if(allocated(pswork))     deallocate(pswork)
+       if(allocated(tvworkvar3d)) deallocate(tvworkvar3d)
+       if(allocated(qworkvar3d)) deallocate(qworkvar3d)
+       if(allocated(qsatworkvar3d)) deallocate(qsatworkvar3d)
     endif
     !======================================================================
-    ! Deallocate memory 
+    ! Deallocate memory
     if(allocated(workvar3d))             deallocate(workvar3d)
-     end do ! ntile loop
+
+    end do ! ntile loop
 
     end do backgroundloop ! loop over backgrounds to read in
-    end do ensmemloop ! loop over ens members to read in 
+    end do ensmemloop ! loop over ens members to read in
 
     return
 
-end subroutine readgriddata
+  end subroutine readgriddata
 
   !========================================================================
-  ! readgriddata: read fv3-lam state or control vector
+  ! writegriddata: write fv3-lam
   !-------------------------------------------------------------------------
 
-
-  !========================================================================
-  ! writegriddata: write fv3-lam 
-  !-------------------------------------------------------------------------
-
-subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid,no_inflate_flag)
+  subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid,no_inflate_flag)
     use constants, only: zero, one,fv,half
-    use gridinfo,only: eta1_ll,eta2_ll    
+    use gridinfo,only: eta1_ll,eta2_ll
     use params, only: nbackgrounds, anlfileprefixes, fgfileprefixes
     use params,   only: nx_res,ny_res,nlevs,ntiles,l_pres_add_saved
     use netcdf, only: nf90_open,nf90_close,nf90_get_var,nf90_noerr
@@ -396,7 +375,7 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
     use netcdf, only: nf90_write,nf90_write,nf90_inquire,nf90_inquire_dimension
     use write_fv3regional_restarts,only:write_fv3_restart_data1d,write_fv3_restart_data2d
     use write_fv3regional_restarts,only:write_fv3_restart_data3d,write_fv3_restart_data4d
-    include 'netcdf.inc'      
+    include 'netcdf.inc'
 
     !----------------------------------------------------------------------
     ! Define variables passed to subroutine
@@ -418,7 +397,7 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
     integer(i_kind) :: w_ind, cw_ind, ph_ind
 
     integer(i_kind) file_id
-      real(r_single), dimension(:,:), allocatable ::pswork
+    real(r_single), dimension(:,:), allocatable ::pswork
     real(r_single), dimension(:,:,:), allocatable ::workvar3d,workinc3d,workinc3d2,uworkvar3d,&
                         vworkvar3d,tvworkvar3d,tsenworkvar3d,&
                         workprsi,qworkvar3d,qsvworkvar3d,qbgworkvar3d
@@ -436,10 +415,8 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
     ! Define counting variables
     integer :: i,j,k,nn,ntile,nn_tile0, nb,ne,nanal
 
-
-    
     write(6,*)"anlfileprefixes, fgfileprefixes are not used in the current implementation", &
-               anlfileprefixes, fgfileprefixes  
+               anlfileprefixes, fgfileprefixes
     write(6,*)"the no_inflate_flag is not used in the currrent implementation ",no_inflate_flag
     !----------------------------------------------------------------------
     nlevsp1=nlevs+1
@@ -474,61 +451,58 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
     allocate(qbgworkvar3d(nx_res,ny_res,nlevs))
     allocate(tvworkvar3d(nx_res,ny_res,nlevs))
 
-
-
     !----------------------------------------------------------------------
     ! First guess file should be copied to analysis file at scripting
     ! level; only variables updated by EnKF are changed
-      write(charnanal,'(a3, i3.3)') 'mem', nanal
+    write(charnanal,'(a3, i3.3)') 'mem', nanal
 
     !----------------------------------------------------------------------
     ! Update u and v variables (same for NMM and ARW)
     do ntile=1,ntiles
-      nn_tile0=(ntile-1)*nx_res*ny_res
-      write(char_tile, '(i1)') ntile
-      filename = "fv3sar_tile"//char_tile//"_"//trim(charnanal)
-      fv3filename=trim(adjustl(filename))//"_dynvartracer"
 
+    nn_tile0=(ntile-1)*nx_res*ny_res
+    write(char_tile, '(i1)') ntile
+    filename = "fv3sar_tile"//char_tile//"_"//trim(charnanal)
+    fv3filename=trim(adjustl(filename))//"_dynvartracer"
 
     !----------------------------------------------------------------------
     ! read u-component
-      call nc_check( nf90_open(trim(adjustl(fv3filename)),nf90_write,file_id),&
-        myname_,'open: '//trim(adjustl(fv3filename)) )
-
+    call nc_check( nf90_open(trim(adjustl(fv3filename)),nf90_write,file_id),&
+      myname_,'open: '//trim(adjustl(fv3filename)) )
 
     ! update CWM for WRF-NMM
     if (u_ind > 0) then
        varstrname = 'u'
        allocate(uworkvar3d(nx_res,ny_res+1,nlevs))
-         
+
        call read_fv3_restart_data3d(varstrname,fv3filename,file_id,uworkvar3d)
-      do k=1,nlevs
+       do k=1,nlevs
           nn = nn_tile0
-      do j=1,ny_res
-         do i=1,nx_res
-            nn=nn+1
-            workinc3d(i,j,k)=vargrid(nn,levels(u_ind-1)+k,nb,ne) 
-         enddo
-      enddo
-      enddo
-      uworkvar3d(:,1:ny_res,:)=uworkvar3d(:,1:ny_res,:)+workinc3d
-      uworkvar3d(:,ny_res+1,:)=uworkvar3d(:,ny_res,:)
+       do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             workinc3d(i,j,k)=vargrid(nn,levels(u_ind-1)+k,nb,ne)
+          enddo
+       enddo
+       enddo
+       uworkvar3d(:,1:ny_res,:)=uworkvar3d(:,1:ny_res,:)+workinc3d
+       uworkvar3d(:,ny_res+1,:)=uworkvar3d(:,ny_res,:)
+
        call write_fv3_restart_data3d(varstrname,fv3filename,file_id,uworkvar3d)
        deallocate(uworkvar3d)
-
     endif
 
     if (v_ind > 0) then
        varstrname = 'v'
        allocate(vworkvar3d(nx_res+1,ny_res,nlevs))
-         
+
        call read_fv3_restart_data3d(varstrname,fv3filename,file_id,vworkvar3d)
        do k=1,nlevs
            nn = nn_tile0
        do j=1,ny_res
           do i=1,nx_res
              nn=nn+1
-             workinc3d(i,j,k)=vargrid(nn,levels(v_ind-1)+k,nb,ne) 
+             workinc3d(i,j,k)=vargrid(nn,levels(v_ind-1)+k,nb,ne)
           enddo
        enddo
        enddo
@@ -538,49 +512,48 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
 
        deallocate(vworkvar3d)
     endif
+
     if(delp_ind>0) then
-    
        varstrname='delp'
        call read_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
-         do k=1,nlevs
-             nn = nn_tile0
-         do j=1,ny_res
-            do i=1,nx_res
-               nn=nn+1
-               workinc3d(i,j,k)=vargrid(nn,levels(delp_ind-1)+k,nb,ne) 
-            enddo
-         enddo
-         enddo
-       workvar3d=workvar3d+workinc3d   
-     
+       do k=1,nlevs
+          nn = nn_tile0
+       do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             workinc3d(i,j,k)=vargrid(nn,levels(delp_ind-1)+k,nb,ne)
+          enddo
+       enddo
+       enddo
+       workvar3d=workvar3d+workinc3d
+
        call write_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
        do k=1,nlevs
-          if (nproc .eq. 0)                                               &
+          if (nproc .eq. 0)                                                &
              write(6,*) 'WRITEregional : delp ',                           &
                  & k, minval(workvar3d(:,:,k)), maxval(workvar3d(:,:,k))
        enddo
     end if
 
     if(q_ind>0) then
-    
        varstrname='sphum'
        call read_fv3_restart_data3d(varstrname,fv3filename,file_id,qbgworkvar3d)
-         do k=1,nlevs
-             nn = nn_tile0
-         do j=1,ny_res
-            do i=1,nx_res
-               nn=nn+1
-               workinc3d(i,j,k)=vargrid(nn,levels(q_ind-1)+k,nb,ne) 
-            enddo
-         enddo
-         enddo
-       qworkvar3d=qbgworkvar3d+workinc3d   
+       do k=1,nlevs
+           nn = nn_tile0
+       do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             workinc3d(i,j,k)=vargrid(nn,levels(q_ind-1)+k,nb,ne)
+          enddo
+       enddo
+       enddo
+       qworkvar3d=qbgworkvar3d+workinc3d
        ! save the original qworkvar3d before writing
        qsvworkvar3d=qworkvar3d
-     
+
        call write_fv3_restart_data3d(varstrname,fv3filename,file_id,qworkvar3d)
        do k=1,nlevs
-          if (nproc .eq. 0)                                               &
+          if (nproc .eq. 0)                                                 &
              write(6,*) 'WRITEregional : sphum ',                           &
                  & k, minval(qworkvar3d(:,:,k)), maxval(qworkvar3d(:,:,k))
        enddo
@@ -590,144 +563,134 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
        qworkvar3d=qsvworkvar3d
     end if
 
-    if (tv_ind > 0.or.tsen_ind>0 ) then
-         
-      varstrname = 'T'
-      if(tsen_ind>0) then
-        do k=1,nlevs
-           nn = nn_tile0
-         do j=1,ny_res
-            do i=1,nx_res
-               nn=nn+1
-               workinc3d(i,j,k)=vargrid(nn,levels(tsen_ind-1)+k,nb,ne) 
-            enddo
-         enddo
-        enddo
-      call read_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
-      workvar3d=workvar3d+workinc3d
-      call write_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
-      else  ! tv_ind >0  
-        do k=1,nlevs
-           nn = nn_tile0
-           do j=1,ny_res
+    if (tv_ind>0 .or. tsen_ind>0 ) then
+       varstrname = 'T'
+       if (tsen_ind>0) then
+          do k=1,nlevs
+             nn = nn_tile0
+          do j=1,ny_res
              do i=1,nx_res
                 nn=nn+1
-                workinc3d(i,j,k)=vargrid(nn,levels(tv_ind-1)+k,nb,ne) 
+                workinc3d(i,j,k)=vargrid(nn,levels(tsen_ind-1)+k,nb,ne)
              enddo
-           enddo
-         enddo
-
-         varstrname = 'T'
-         allocate(tsenworkvar3d(nx_res,ny_res,nlevs))
-         call read_fv3_restart_data3d(varstrname,fv3filename,file_id,tsenworkvar3d)
-         if(.not. (q_ind > 0) ) then
-           varstrname = 'sphum'
-           call read_fv3_restart_data3d(varstrname,fv3filename,file_id,qbgworkvar3d)
-         endif 
-         tvworkvar3d=tsenworkvar3d*(one+fv*qbgworkvar3d)
-         tvworkvar3d=tvworkvar3d+workinc3d
-         if(.not. ( q_ind > 0)) then
-            tsenworkvar3d=tvworkvar3d/(one+fv*qbgworkvar3d)
-         else
-            tsenworkvar3d=tvworkvar3d/(one+fv*qworkvar3d)
-         endif
-         varstrname = 'T'
-         call write_fv3_restart_data3d(varstrname,fv3filename,file_id,tsenworkvar3d)
-         do k=1,nlevs
-           if (nproc .eq. 0)                                               &
-             write(6,*) 'WRITEregional : T ',                           &
-                 & k, minval(tsenworkvar3d(:,:,k)), maxval(tsenworkvar3d(:,:,k))
-         enddo
-       
-         deallocate(tsenworkvar3d)
-      endif  !if tsens else tv
-
+          enddo
+          enddo
+          call read_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
+          workvar3d=workvar3d+workinc3d
+          call write_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
+       else ! tv_ind >0
+          do k=1,nlevs
+             nn = nn_tile0
+          do j=1,ny_res
+             do i=1,nx_res
+                nn=nn+1
+                workinc3d(i,j,k)=vargrid(nn,levels(tv_ind-1)+k,nb,ne)
+             enddo
+          enddo
+          enddo
+          varstrname = 'T'
+          allocate(tsenworkvar3d(nx_res,ny_res,nlevs))
+          call read_fv3_restart_data3d(varstrname,fv3filename,file_id,tsenworkvar3d)
+          if (.not. (q_ind>0) ) then
+             varstrname = 'sphum'
+             call read_fv3_restart_data3d(varstrname,fv3filename,file_id,qbgworkvar3d)
+          endif
+          tvworkvar3d=tsenworkvar3d*(one+fv*qbgworkvar3d)
+          tvworkvar3d=tvworkvar3d+workinc3d
+          if (.not. (q_ind>0)) then
+             tsenworkvar3d=tvworkvar3d/(one+fv*qbgworkvar3d)
+          else
+             tsenworkvar3d=tvworkvar3d/(one+fv*qworkvar3d)
+          endif
+          varstrname = 'T'
+          call write_fv3_restart_data3d(varstrname,fv3filename,file_id,tsenworkvar3d)
+          do k=1,nlevs
+             if (nproc .eq. 0)                                               &
+                write(6,*) 'WRITEregional : T ',                             &
+                  & k, minval(tsenworkvar3d(:,:,k)), maxval(tsenworkvar3d(:,:,k))
+          enddo
+          deallocate(tsenworkvar3d)
+      endif !if tsens else tv
     endif
-    
+
     if (oz_ind > 0) then
        varstrname = 'o3mr'
-         
        call read_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
-      do k=1,nlevs
+       do k=1,nlevs
           nn = nn_tile0
-      do j=1,ny_res
-         do i=1,nx_res
-            nn=nn+1
-            workinc3d(i,j,k)=vargrid(nn,levels(oz_ind-1)+k,nb,ne) 
-         enddo
-      enddo
-      enddo
-      workvar3d=workvar3d+workinc3d
+       do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             workinc3d(i,j,k)=vargrid(nn,levels(oz_ind-1)+k,nb,ne)
+          enddo
+       enddo
+       enddo
+       workvar3d=workvar3d+workinc3d
        call write_fv3_restart_data3d(varstrname,fv3filename,file_id,workvar3d)
-
     endif
-      if (ps_ind > 0) then
+
+    if (ps_ind > 0) then
        allocate(workprsi(nx_res,ny_res,nlevsp1))
        allocate(pswork(nx_res,ny_res))
        varstrname = 'delp'
-      call read_fv3_restart_data3d(varstrname,filename,file_id,workvar3d)  
-      !print *,'min/max delp',ntile,minval(delp),maxval(delp)
-      workprsi(:,:,nlevsp1)=eta1_ll(nlevsp1) !etal_ll is needed
-      do i=nlevs,1,-1
-        workprsi(:,:,i)=workvar3d(:,:,i)*0.01_r_kind+workprsi(:,:,i+1)
+       call read_fv3_restart_data3d(varstrname,filename,file_id,workvar3d)
+       !print *,'min/max delp',ntile,minval(delp),maxval(delp)
+       workprsi(:,:,nlevsp1)=eta1_ll(nlevsp1) !etal_ll is needed
+       do i=nlevs,1,-1
+          workprsi(:,:,i)=workvar3d(:,:,i)*0.01_r_kind+workprsi(:,:,i+1)
        enddo
 
-      nn = nn_tile0
-      do j=1,ny_res
-         do i=1,nx_res
-            nn=nn+1
-            pswork(i,j)=vargrid(nn,levels(n3d)+ps_ind,nb,ne)
-         enddo
-      enddo
-     if(l_pres_add_saved) then
-      do k=1,nlevs+1
-      do j=1,ny_res
-         do i=1,nx_res
-            workinc3d2(i,j,k)=eta2_ll(k)*pswork(i,j)
-         enddo
-      enddo
-      enddo
-      workprsi=workprsi+workinc3d2
-     else
-        workprsi(:,:,1)=workprsi(:,:,1)+pswork
-        do k=2,nlevsp1
-        workprsi(:,:,k)=eta1_ll(k)+eta2_ll(k)*workprsi(:,:,1)
-        enddo
-     endif
-       do k=1,nlevs
-        workvar3d(:,:,k)=(workprsi(:,:,k)-workprsi(:,:,k+1))*100.0
+       nn = nn_tile0
+       do j=1,ny_res
+          do i=1,nx_res
+             nn=nn+1
+             pswork(i,j)=vargrid(nn,levels(n3d)+ps_ind,nb,ne)
+          enddo
        enddo
-        
+       if (l_pres_add_saved) then
+          do k=1,nlevs+1
+          do j=1,ny_res
+             do i=1,nx_res
+                workinc3d2(i,j,k)=eta2_ll(k)*pswork(i,j)
+             enddo
+          enddo
+          enddo
+          workprsi=workprsi+workinc3d2
+       else
+          workprsi(:,:,1)=workprsi(:,:,1)+pswork
+          do k=2,nlevsp1
+          workprsi(:,:,k)=eta1_ll(k)+eta2_ll(k)*workprsi(:,:,1)
+          enddo
+       endif
+       do k=1,nlevs
+          workvar3d(:,:,k)=(workprsi(:,:,k)-workprsi(:,:,k+1))*100.0
+       enddo
 
        call write_fv3_restart_data3d(varstrname,filename,file_id,workvar3d)
-     endif
- 
+    endif
+
     call nc_check( nf90_close(file_id),&
-      myname_,'close '//trim(filename) )
+                   myname_,'close '//trim(filename) )
 
+    end do ! tiles
 
-     end do ! tiles
-    if(allocated(workinc3d))     deallocate(workinc3d)
-    if(allocated(workinc3d2))     deallocate(workinc3d2)
+    if(allocated(workinc3d))    deallocate(workinc3d)
+    if(allocated(workinc3d2))   deallocate(workinc3d2)
     if(allocated(workprsi))     deallocate(workprsi)
-   if(allocated(pswork))     deallocate(pswork)
-   if(allocated(tvworkvar3d)) deallocate(tvworkvar3d)
-   if(allocated(qworkvar3d)) deallocate(qworkvar3d)
-   if(allocated(qbgworkvar3d)) deallocate(qbgworkvar3d)
+    if(allocated(pswork))       deallocate(pswork)
+    if(allocated(tvworkvar3d))  deallocate(tvworkvar3d)
+    if(allocated(qworkvar3d))   deallocate(qworkvar3d)
+    if(allocated(qsvworkvar3d)) deallocate(qsvworkvar3d)
+    if(allocated(qbgworkvar3d)) deallocate(qbgworkvar3d)
 
-
-
-  
     end do backgroundloop ! loop over backgrounds to read in
     end do ensmemloop ! loop over ens members to read in
-
 
     ! Return calculated values
     return
 
-    !======================================================================
-
   end subroutine writegriddata
+
   subroutine writeincrement(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,grdin,no_inflate_flag)
  !Dummy subroutine declaration in place of  the actual subroutine definition in
  !the GFS EnKF
@@ -758,7 +721,7 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
     real(r_single), dimension(npts,ndim,nbackgrounds,1), intent(inout) :: grdin
     logical, intent(in) :: no_inflate_flag
   end subroutine writeincrement_pnc
-  
+
   subroutine readgriddata_pnc(vars3d,vars2d,n3d,n2d,levels,ndim,ntimes, &
                                fileprefixes,filesfcprefixes,reducedgrid,grdin,qsat)
  !Dummy subroutine declaration in place of  the actual subroutine definition in
@@ -792,6 +755,5 @@ subroutine writegriddata(nanal1,nanal2,vars3d,vars2d,n3d,n2d,levels,ndim,vargrid
     real(r_single), dimension(npts,ndim,nbackgrounds,1), intent(inout) :: grdin
     logical, intent(in) :: no_inflate_flag
   end subroutine writegriddata_pnc
-
 
 end module gridio


### PR DESCRIPTION
*Bug fix for EnKF analysis steps when using t (tv) as a control vector variable for regional FV3 DA.

Notes: 
- This PR addresses issue #13, which was reported by Jonathan Poterjoy (UMD). 
- And this bug should have affected all the EnKF steps (mean, update, recenter, etc.)
- The bug fix is based on the diagnoses and discussions among @BinLiu-NOAA and @TingLei-NOAA (EMC), @XL-OU, Jonathan Poterjoy (UMD), Jason Sippel (HRD), etc.
- Besides, whitespace and indentation clean-ups were made in src/enkf/gridio_fv3reg.f90.

