### PR TITLE
Bug fixes and optimizations to the dual-resolution EnVar

### DIFF
--- a/src/gsi/cplr_get_fv3_regional_ensperts.f90
+++ b/src/gsi/cplr_get_fv3_regional_ensperts.f90
@@ -392,69 +392,38 @@ contains
       
 
 !cltthinktobe  should be contained in variable like grd_ens
-    if (dual_res) then
       if(fv3sar_ensemble_opt == 0 ) then
-        call gsi_fv3ncdf_readuv(dynvars,g_u,g_v,grd_ens%lat2,grd_ens%lon2,.true.)
+        call gsi_fv3ncdf_readuv(dynvars,g_u,g_v,grd_ens%lat2,grd_ens%lon2,dual_res)
       else
-        call gsi_fv3ncdf_readuv_v1(dynvars,g_u,g_v,grd_ens%lat2,grd_ens%lon2,.true.)
+        call gsi_fv3ncdf_readuv_v1(dynvars,g_u,g_v,grd_ens%lat2,grd_ens%lon2,dual_res)
       endif
       if(fv3sar_ensemble_opt == 0) then
-        call gsi_fv3ncdf_read(dynvars,'T','t',g_tsen,mype_t,grd_ens%lat2,grd_ens%lon2,.true.)
+        call gsi_fv3ncdf_read(dynvars,'T','t',g_tsen,mype_t,grd_ens%lat2,grd_ens%lon2,dual_res)
       else
-        call gsi_fv3ncdf_read_v1(dynvars,'t','T',g_tsen,mype_t,grd_ens%lat2,grd_ens%lon2,.true.)
+        call gsi_fv3ncdf_read_v1(dynvars,'t','T',g_tsen,mype_t,grd_ens%lat2,grd_ens%lon2,dual_res)
       endif
-    else
-      if(fv3sar_ensemble_opt == 0 ) then
-        call gsi_fv3ncdf_readuv(dynvars,g_u,g_v,grd_ens%lat2,grd_ens%lon2,.false.)
-      else
-        call gsi_fv3ncdf_readuv_v1(dynvars,g_u,g_v,grd_ens%lat2,grd_ens%lon2,.false.)
-      endif
-      if(fv3sar_ensemble_opt == 0) then
-        call gsi_fv3ncdf_read(dynvars,'T','t',g_tsen,mype_t,grd_ens%lat2,grd_ens%lon2,.false.)
-      else
-        call gsi_fv3ncdf_read_v1(dynvars,'t','T',g_tsen,mype_t,grd_ens%lat2,grd_ens%lon2,.false.)
-      endif
-    end if
     if (fv3sar_ensemble_opt == 0) then 
-      if (dual_res) then
-        call gsi_fv3ncdf_read(dynvars,'DELP','delp',g_prsi,mype_p,grd_ens%lat2,grd_ens%lon2,.true.)
-      else
-        call gsi_fv3ncdf_read(dynvars,'DELP','delp',g_prsi,mype_p,grd_ens%lat2,grd_ens%lon2,.false.)
-      end if
+      call gsi_fv3ncdf_read(dynvars,'DELP','delp',g_prsi,mype_p,grd_ens%lat2,grd_ens%lon2,dual_res)
       g_prsi(:,:,grd_ens%nsig+1)=eta1_ll(grd_ens%nsig+1) !thinkto be done , should use eta1_ll from ensemble grid
       do i=grd_ens%nsig,1,-1
          g_prsi(:,:,i)=g_prsi(:,:,i)*0.001_r_kind+g_prsi(:,:,i+1)
       enddo
     g_ps(:,:)=g_prsi(:,:,1)
     else  ! for the ensemble processed frm CHGRES
-      if (dual_res) then
-        call gsi_fv3ncdf2d_read_v1(dynvars,'ps','PS',g_ps,mype_p,grd_ens%lat2,grd_ens%lon2,.true.)
-      else
-        call gsi_fv3ncdf2d_read_v1(dynvars,'ps','PS',g_ps,mype_p,grd_ens%lat2,grd_ens%lon2,.false.)
-      end if
+      call gsi_fv3ncdf2d_read_v1(dynvars,'ps','PS',g_ps,mype_p,grd_ens%lat2,grd_ens%lon2,dual_res)
       g_ps=g_ps*0.001_r_kind
       do k=1,grd_ens%nsig+1
         g_prsi(:,:,k)=eta1_ll(k)+eta2_ll(k)*g_ps
       enddo
     endif
      
-    if (dual_res) then
-      if(fv3sar_ensemble_opt == 0) then
-        call gsi_fv3ncdf_read(tracers,'SPHUM','sphum',g_q,mype_q,grd_ens%lat2,grd_ens%lon2,.true.)
-        call gsi_fv3ncdf_read(tracers,'O3MR','o3mr',g_oz,mype_oz,grd_ens%lat2,grd_ens%lon2,.true.)
-      else
-        call gsi_fv3ncdf_read_v1(tracers,'sphum','SPHUM',g_q,mype_q,grd_ens%lat2,grd_ens%lon2,.true.)
-        call gsi_fv3ncdf_read_v1(tracers,'o3mr','O3MR',g_oz,mype_oz,grd_ens%lat2,grd_ens%lon2,.true.)
-      endif
+    if(fv3sar_ensemble_opt == 0) then
+      call gsi_fv3ncdf_read(tracers,'SPHUM','sphum',g_q,mype_q,grd_ens%lat2,grd_ens%lon2,dual_res)
+      call gsi_fv3ncdf_read(tracers,'O3MR','o3mr',g_oz,mype_oz,grd_ens%lat2,grd_ens%lon2,dual_res)
     else
-      if(fv3sar_ensemble_opt == 0) then
-        call gsi_fv3ncdf_read(tracers,'SPHUM','sphum',g_q,mype_q,grd_ens%lat2,grd_ens%lon2,.false.)
-        call gsi_fv3ncdf_read(tracers,'O3MR','o3mr',g_oz,mype_oz,grd_ens%lat2,grd_ens%lon2,.false.)
-      else
-        call gsi_fv3ncdf_read_v1(tracers,'sphum','SPHUM',g_q,mype_q,grd_ens%lat2,grd_ens%lon2,.false.)
-        call gsi_fv3ncdf_read_v1(tracers,'o3mr','O3MR',g_oz,mype_oz,grd_ens%lat2,grd_ens%lon2,.false.)
-      endif
-    end if
+      call gsi_fv3ncdf_read_v1(tracers,'sphum','SPHUM',g_q,mype_q,grd_ens%lat2,grd_ens%lon2,dual_res)
+      call gsi_fv3ncdf_read_v1(tracers,'o3mr','O3MR',g_oz,mype_oz,grd_ens%lat2,grd_ens%lon2,dual_res)
+    endif
 
 !!  tsen2tv  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     do k=1,grd_ens%nsig

--- a/src/gsi/gridmod.F90
+++ b/src/gsi/gridmod.F90
@@ -131,7 +131,7 @@ module gridmod
   public :: strip_periodic
 
 ! set passed variables to public
-  public :: nnnn1o,iglobal,itotsub,ijn,ijn_s,lat2,lon2,lat1,lon1,nsig,nsig_soil
+  public :: nnnn1o,iglobal,itotsub,ijn,ijn_s,lat2,lon2,lat1,lon1,nsig,nsig_soil,itotsubens
   public :: ncloud,nlat,nlon,ntracer,displs_s,displs_g
   public :: ijn_sens,ijnens,displs_sens
   public :: bk5,regional,latlon11,latlon1n,twodvar_regional
@@ -262,6 +262,7 @@ module gridmod
   integer(i_kind) latlon1n1         ! no. of points in subdomain for 3d prs (with buffer)
   integer(i_kind) iglobal           ! number of horizontal points on global grid
   integer(i_kind) itotsub           ! number of horizontal points of all subdomains combined
+  integer(i_kind) itotsubens           ! number of horizontal points of all subdomains combined
   integer(i_kind) msig              ! number of profile layers to use when calling RTM
 
   integer(i_kind) jcap_cut          ! spectral triangular truncation beyond which you recalculate pln and plntop - default 600 - used to save memory

--- a/src/gsi/gsi_rfv3io_mod.f90
+++ b/src/gsi/gsi_rfv3io_mod.f90
@@ -350,7 +350,6 @@ subroutine gsi_rfv3io_get_grid_specs(fv3filenamegin,ierr)
                              coeffx,coeffy)
 
 
-
     deallocate (grid_lon,grid_lat,grid_lont,grid_latt)
     deallocate (ak,bk,abk_fv3)
 
@@ -428,7 +427,6 @@ subroutine gsi_rfv3io_get_ens_grid_specs(grid_spec,ierr)
        ierr=1
        return
     endif
-
     iret=nf90_inquire(gfile_grid_spec,ndimensions,nvariables,nattributes,unlimiteddimid)
     gfile_loc=gfile_grid_spec
     do k=1,ndimensions
@@ -464,7 +462,6 @@ subroutine gsi_rfv3io_get_ens_grid_specs(grid_spec,ierr)
     iret=nf90_close(gfile_loc)
 
 !!!    get ak,bk
-
 
 
 !!!!!!! setup A grid and interpolation/rotation coeff.
@@ -753,7 +750,7 @@ subroutine read_fv3_netcdf_guess(fv3filenamegin,it)
 !
 !$$$  end documentation block
     use kinds, only: r_kind,i_kind
-    use mpimod, only: npe
+    use mpimod, only: npe,mype
     use guess_grids, only: ges_tsen,ges_prsi
     use gridmod, only: lat2,lon2,nsig,ijn,eta1_ll,eta2_ll,ijn_s
     use gridmod, only: ijnens,ijn_sens
@@ -1129,7 +1126,7 @@ subroutine gsi_fv3ncdf2d_read_v1(filenamein,varname,varname2,work_sub,mype_io,la
     use netcdf, only: nf90_inquire_variable
     use mod_fv3_lolgrid, only: fv3_h_to_ll_regular_grids
     use general_commvars_mod, only: ltosi_s,ltosj_s
-    use gridmod, only: ijn_sens,ijnens,displs_sens
+    use gridmod, only: ijn_sens,ijnens,displs_sens,itotsubens
     use general_commvars_mod, only: ltosi_sens,ltosj_sens
     use hybrid_ensemble_parameters, only: nlon_ens,nlat_ens
 
@@ -1151,7 +1148,11 @@ subroutine gsi_fv3ncdf2d_read_v1(filenamein,varname,varname2,work_sub,mype_io,la
     integer(i_kind) ndimensions,nvariables,nattributes,unlimiteddimid
 
     mm1=mype+1
-    allocate (work(itotsub))
+    if (ensgrid) then
+     allocate (work(itotsubens))
+    else
+     allocate (work(itotsub))
+    endif
 
     if(mype==mype_io ) then
        iret=nf90_open(trim(filenamein),nf90_nowrite,gfile_loc)
@@ -1260,7 +1261,7 @@ subroutine gsi_fv3ncdf_read(filenamein,varname,varname2,work_sub,mype_io,lat2in,
     use netcdf, only: nf90_inquire_variable
     use mod_fv3_lolgrid, only: fv3_h_to_ll_regular_grids
     use general_commvars_mod, only: ltosi_s,ltosj_s
-    use gridmod, only: ijn_sens,ijnens
+    use gridmod, only: ijn_sens,ijnens,itotsubens
     use general_commvars_mod, only: ltosi_sens,ltosj_sens
     use hybrid_ensemble_parameters, only: nlon_ens,nlat_ens
 
@@ -1283,7 +1284,11 @@ subroutine gsi_fv3ncdf_read(filenamein,varname,varname2,work_sub,mype_io,lat2in,
     integer(i_kind) ndimensions,nvariables,nattributes,unlimiteddimid
 
     mm1=mype+1
-    allocate (work(itotsub*nsig))
+    if (ensgrid) then
+     allocate (work(itotsubens*nsig))
+    else
+     allocate (work(itotsub*nsig))
+    endif
 
     if(mype==mype_io ) then
        iret=nf90_open(trim(filenamein),nf90_nowrite,gfile_loc)
@@ -1407,7 +1412,7 @@ subroutine gsi_fv3ncdf_read_v1(filenamein,varname,varname2,work_sub,mype_io,lat2
     use netcdf, only: nf90_inq_varid
     use mod_fv3_lolgrid, only: fv3_h_to_ll_regular_grids
     use general_commvars_mod, only: ltosi_s,ltosj_s
-    use gridmod, only: lat2,lon2,nsig,nlat,nlon,itotsub,ijn_s,ijn_sens
+    use gridmod, only: lat2,lon2,nsig,nlat,nlon,itotsub,ijn_s,ijn_sens,itotsubens
     use general_commvars_mod, only: ltosi_sens,ltosj_sens
     use hybrid_ensemble_parameters, only: nlon_ens,nlat_ens
     implicit none
@@ -1430,7 +1435,11 @@ subroutine gsi_fv3ncdf_read_v1(filenamein,varname,varname2,work_sub,mype_io,lat2
     integer(i_kind) ndimensions,nvariables,nattributes,unlimiteddimid
 
     mm1=mype+1
-    allocate (work(itotsub*nsig))
+    if (ensgrid) then
+     allocate (work(itotsubens*nsig))
+    else
+     allocate (work(itotsub*nsig))
+    endif
 
     if(mype==mype_io ) then
        iret=nf90_open(trim(filenamein),nf90_nowrite,gfile_loc)
@@ -1552,7 +1561,7 @@ subroutine gsi_fv3ncdf_readuv(dynvarsfile,ges_u,ges_v,lat2in,lon2in,ensgrid)
     use netcdf, only: nf90_inq_varid
     use mod_fv3_lolgrid, only: fv3_h_to_ll_regular_grids,nya,nxa,fv3uv2earth_regular_grids
     use general_commvars_mod, only: ltosi_s,ltosj_s
-    use gridmod, only: ijn_sens,ijnens
+    use gridmod, only: ijn_sens,ijnens,itotsubens
     use general_commvars_mod, only: ltosi_sens,ltosj_sens
     use hybrid_ensemble_parameters, only: nlon_ens,nlat_ens
 
@@ -1574,7 +1583,11 @@ subroutine gsi_fv3ncdf_readuv(dynvarsfile,ges_u,ges_v,lat2in,lon2in,ensgrid)
     integer(i_kind) nz,nzp1,kk,j,mm1,i,ir,ii,jj
     integer(i_kind) ndimensions,nvariables,nattributes,unlimiteddimid
 
-    allocate (work(itotsub*nsig))
+    if (ensgrid) then
+     allocate (work(itotsubens*nsig))
+    else
+     allocate (work(itotsub*nsig))
+    endif
     mm1=mype+1
     if(mype==mype_u .or. mype==mype_v) then
        iret=nf90_open(dynvarsfile,nf90_nowrite,gfile_loc)
@@ -1717,7 +1730,7 @@ subroutine gsi_fv3ncdf_readuv_v1(dynvarsfile,ges_u,ges_v,lat2in,lon2in,ensgrid)
     use netcdf, only: nf90_inq_varid
     use mod_fv3_lolgrid, only: fv3_h_to_ll_regular_grids,nya,nxa,fv3uv2earth_regular_grids
     use general_commvars_mod, only: ltosi_s,ltosj_s
-    use gridmod, only: ijn_sens,ijnens
+    use gridmod, only: ijn_sens,ijnens,itotsubens
     use general_commvars_mod, only: ltosi_sens,ltosj_sens
     use hybrid_ensemble_parameters, only: nlon_ens,nlat_ens
     implicit none
@@ -1738,7 +1751,11 @@ subroutine gsi_fv3ncdf_readuv_v1(dynvarsfile,ges_u,ges_v,lat2in,lon2in,ensgrid)
     integer(i_kind) nztmp,nzp1,kk,j,mm1,i,ir,ii,jj
     integer(i_kind) ndimensions,nvariables,nattributes,unlimiteddimid
 
-    allocate (work(itotsub*nsig))
+    if (ensgrid) then
+     allocate (work(itotsubens*nsig))
+    else
+     allocate (work(itotsub*nsig))
+    endif
     mm1=mype+1
     if(mype==mype_u .or. mype==mype_v) then
        iret=nf90_open(dynvarsfile,nf90_nowrite,gfile_loc)

--- a/src/gsi/hybrid_ensemble_isotropic.F90
+++ b/src/gsi/hybrid_ensemble_isotropic.F90
@@ -3875,7 +3875,7 @@ subroutine hybens_grid_setup
   use hybrid_ensemble_parameters, only:regional_ensemble_option 
   use gsi_rfv3io_mod,only:gsi_rfv3io_get_ens_grid_specs
   use general_commvars_mod, only: ltosi_sens,ltosj_sens
-  use gridmod, only: itotsub,ijn_sens,ijnens,displs_sens
+  use gridmod, only: itotsub,ijn_sens,ijnens,displs_sens,itotsubens
   use mpimod, only: npe
 
   implicit none
@@ -3943,11 +3943,6 @@ subroutine hybens_grid_setup
   allocate(vector(num_fields))
   vector=.false.
   call general_sub2grid_create_info(grd_loc,inner_vars,nlat_ens,nlon_ens,nsig,num_fields,regional,vector)
-  ltosi_sens=grd_loc%ltosi_s
-  ltosj_sens=grd_loc%ltosj_s
-  ijn_sens=grd_loc%ijn_s
-  ijnens=grd_loc%ijn
-  displs_sens=grd_loc%displs_s
   num_fields=max(0,nc3d)*nsig+max(0,nc2d)
   deallocate(vector)
   allocate(vector(num_fields))
@@ -3977,6 +3972,12 @@ subroutine hybens_grid_setup
                                nord_e2a,p_e2a,.true.,eqspace=use_sp_eqspace)
   else
      if(dual_res) then
+        ltosi_sens=grd_ens%ltosi_s
+        ltosj_sens=grd_ens%ltosj_s
+        ijn_sens=grd_ens%ijn_s
+        ijnens=grd_ens%ijn
+        itotsubens=grd_ens%itotsub
+        displs_sens=grd_ens%displs_s
 !cltthinktodo
         call get_region_dx_dy_ens(region_dx_ens,region_dy_ens)
         if(regional_ensemble_option) then

--- a/src/gsi/mod_fv3_lolgrid.f90
+++ b/src/gsi/mod_fv3_lolgrid.f90
@@ -814,8 +814,10 @@ subroutine definecoef_regular_grids(nx,ny,nxa_inout,nya_inout,grid_lon,grid_lont
      cy=one
   endif
   allocate(rlat_in(nlatin,nlonin),rlon_in(nlatin,nlonin))
+  region_lon_in=region_lon_in*rad2deg
+  region_lat_in=region_lat_in*rad2deg
   call rotate2deg(region_lon_in,region_lat_in,rlon_in,rlat_in, &
-                    clon,clat,nlatin,nlonin)
+                    centlon,centlat,nlatin,nlonin)
 
 !
 !-----setup analysis A-grid from center of the domain


### PR DESCRIPTION
Bug fixes and optimizations to the dual-resolution by @XL-OU & Xuguang Wang from OU, POC:  xuguang.wang@ou.edu

  1. change region_lat/lon_in to degree & replace clon/clat with centlon/centlat in rotate2deg
  2. add itotsubens for ensemble domain in gridmod.f90 & gsi_rfv3io_mod.f90
  3. use grd_ens instead of grd_loc for ensemble grid indexes in hybrid_ensemble_isotropic.F90
  4. reduce duplication of dual_res in cplr_get_fv3_regional_ensperts.f90